### PR TITLE
overlay: Advertise camera button presence for qwerty devices

### DIFF
--- a/overlay/frameworks/base/core/res/res/values-qwerty/config.xml
+++ b/overlay/frameworks/base/core/res/res/values-qwerty/config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- Hardware 'face' keys present on the device, stored as a bit field.
+         This integer should equal the sum of the corresponding value for each
+         of the following keys present:
+             1 - Home
+             2 - Back
+             4 - Menu
+             8 - Assistant (search)
+            16 - App switch
+            32 - Camera
+         For example, a device with Home, Back and Menu keys would set this
+         config to 7. -->
+    <integer name="config_deviceHardwareKeys">32</integer>
+</resources>

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -54,4 +54,8 @@
 
     <!-- Enables swipe versus poly-finger touch disambiguation in the KeyboardView -->
     <bool name="config_swipeDisambiguation">true</bool>
+
+    <!-- Indicates that the device has Single-stage Camera key
+         (without "Focus" state) instead of Dual-stage. -->
+    <bool name="config_singleStageCameraKey">true</bool>
 </resources>


### PR DESCRIPTION
- xt897 is the only moto_msm8960 family member with physical
  camera button while it's also the only qwerty device, so let's
  indicate the camera button presence based on the qwerty
  availability
- while this is not always correct in the case of an external
  keyboard connected to a non-qwerty moto-msm8960 device,
  it covers the majority of use cases quite well anyway

Change-Id: I7e1a8ac6a7bc00736ff838e39f08d30a40d6392e
